### PR TITLE
notebook launch with browser widget

### DIFF
--- a/expipecli/main.py
+++ b/expipecli/main.py
@@ -44,7 +44,7 @@ class Default(IPlugin):
             """Create a project."""
             cwd = pathlib.Path.cwd()
             try:
-                expipe_module.create_project(path=cwd, name=project_id)
+                expipe_module.create_project(path=cwd / project_id)
             except KeyError as e:
                 print(str(e))
 

--- a/expipecli/utils/browser-template.ipynb
+++ b/expipecli/utils/browser-template.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import expipe\n",
+    "from expipe.widgets.browser import Browser "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_path = '/home/mikkel/expipe/septum-mec'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b = Browser(project_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b.display()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
`expipe browser --run` inside a project opens up a notebook from template, saves it in the project root and launches it